### PR TITLE
Make it more generic, with more debug. cap.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 vendor
 var
 .idea
+composer.lock
+.tmp
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,18 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
-RUN apt-get update && apt-get install -y zlib1g-dev git \
-    && git clone --depth=1 https://github.com/NoiseByNorthwest/php-spx.git /usr/lib/php-spx \
-    && cd /usr/lib/php-spx \
+COPY .tmp/php-spx /tmp/php-spx
+
+RUN apt-get update && apt-get install -y zlib1g-dev git gdb \
+    && cd /tmp/php-spx \
     && phpize \
     && ./configure \
     && make \
     && make install \
     && rm -rf /var/lib/apt/lists/*
 
-RUN  echo "extension=spx.so" > /usr/local/etc/php/conf.d/docker-php-ext-spx.ini
+RUN echo > /usr/local/etc/php/conf.d/docker-php-ext-spx.ini \
+   && echo 'extension=spx.so' >> /usr/local/etc/php/conf.d/docker-php-ext-spx.ini \
+   && echo 'spx.http_enabled=1' >> /usr/local/etc/php/conf.d/docker-php-ext-spx.ini \
+   && echo 'spx.http_key="dev"' >> /usr/local/etc/php/conf.d/docker-php-ext-spx.ini \
+   && echo 'spx.http_ip_whitelist="*"' >> /usr/local/etc/php/conf.d/docker-php-ext-spx.ini

--- a/README.md
+++ b/README.md
@@ -1,31 +1,50 @@
-# SPX Issue Reproduction
+# FrankenPHP & SPX integration
 
-This repository demonstrates the issue with SPX UI not showing up in FrankenPHP.
-Issue reference: https://github.com/NoiseByNorthwest/php-spx/issues/258
+This repository provides a Docker-based infrastructure which can help to reproduce or debug issues related to the integration of FrankenPHP with SPX.
 
 ## Setup
 
+First make sure that you have a clone of php-spx located at this relative path `../php-spx`.
+
+Then run the following command to build the image:
+
 ```bash
-# Build and run the container
-docker build -t frankenphp-spx .
-docker run --rm -v $PWD:/app/public -p 80:80 -p 443:443 -p 443:443/udp --tty frankenphp-spx
+./build.sh
 ```
 
-## Testing SPX Web Interface (Not Working)
+And then run FrankenPHP:
 
-1. Run `composer update` to install dependencies
-2. Visit https://localhost/?SPX_KEY=dev&SPX_UI_URI=/
-3. Expected: SPX UI should appear
-4. Actual: SPX UI doesn't show up
+```bash
+docker run --rm -v $PWD:/app/public -p 8501:80 -p 8500:443 -p 8500:443/udp --cap-add=SYS_PTRACE --tty --name frankenphp-spx frankenphp-spx
+> c (continue) / bt (backtrace)
+```
+
+## Starting a debugging session
+
+Run the follwowing command to attach GDB to the FrankendPHP process (frankenphp-spx's PID1):
+
+```bash
+docker exec -it frankenphp-spx gdb -p 1
+```
+
+Then, in GDB's prompt, you will be able to enter commands such as `c` (continue) or `bt` (stack's backtrace).
+
+## Testing SPX Web Interface
+
+Run `composer update` to install dependencies:
+
+```bash
+docker exec frankenphp-spx bash -c  'cd public ; composer update'
+```
+
+Then you can access to SPX's web UI here https://localhost:8500/?SPX_KEY=dev&SPX_UI_URI=/
 
 ## Testing CLI Interface (Working)
 
-1. Get container ID:
-   ```bash
-   docker ps
-   ```
-2. Run CLI test:
-   ```bash
-   docker exec -e SPX_ENABLED=1 -ti CONTAINER_ID php public/cli.php
-   ```
-3. You should see SPX profiling output in the terminal
+Run CLI test:
+
+```bash
+docker exec -e SPX_ENABLED=1 -ti CONTAINER_ID php public/cli.php
+```
+
+You should see SPX profiling output in the terminal

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+rsync -av --progress ../php-spx .tmp --exclude .git
+docker build -t frankenphp-spx .


### PR DESCRIPTION
What changed:
- php-spx clone must be already present (more convenient for debugging)
- `build.sh` script is provided
- random port exposed (8500 instead of 443, more convenient when you have many HTTP local servers)
- gdb installed in the image
- full SPX config (HTTP part is now working)
- improved README (more generic, with GDB-based debugging section)